### PR TITLE
Fix transformation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ lambda.context([ctx1, ctx2])
 
 ## Modifiers
 After setting context, you can chain several other functions that modify the operation. Each returns a `Request` object, so they can be chained. All of these are optional.
-### .concurrency(c) 
+### .concurrency(c)
 {Number} Set the request concurrency level (default is `Infinity`).
 
 ### .transform(f)
-{Function} Sets the transformation function to use when getting objects. The function takes the object as an argument, and should return the transformed object.  
+{Function} Sets the transformation function to use when getting objects. This transformer will be called with the raw object that is returned by the [`S3#getObject()`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property) method in the AWS SDK, and should return the transformed object.  When a transformer function is provided, objects are not automatically converted to strings, and the `encoding` parameter is ignored.  
 **Example:** unzipping compressed S3 files before each operation
 ```javascript
 const zlib = require('zlib')
@@ -80,17 +80,17 @@ const zlib = require('zlib')
 lambda
   .context(context)
   .transform((object) => {
-    return zlib.gunzipSync(object).toString()
+    return zlib.gunzipSync(object.Body).toString('utf8')
   })
   .each(...)
 ```
 ### .encode(e)
-{String} Sets the encoding to use when getting objects.
+{String} Sets the string encoding to use when getting objects.  This setting is ignored if a transformer function is used.
 ### limit(l)
 {Number} Limit the number of files operated over.
 ### reverse(r)
 {Boolean} Reverse the order of files operated over.
-### async() 
+### async()
 Lets the resolver know that your function is async (returns a Promise).
 
 ## Lambda Functions
@@ -130,7 +130,7 @@ lambda
 map(fn[, isasync])  
 
 **Destructive**. Maps `fn` over each file in an S3 directory, replacing each file with what is returned
-from the mapper function. If `isasync` is true, `fn` should return a Promise. 
+from the mapper function. If `isasync` is true, `fn` should return a Promise.
 ```javascript
 const addSmiley = object => object + ':)'
 
@@ -230,12 +230,14 @@ lambda
   .then(object => { /* do something with object */ })
   .catch(console.error)
 ```
-Optionally you can supply your own transformer function to use when retrieving objects.
+
+Optionally you can supply your own transformer function to use when retrieving objects.  This transformer will be called with the raw object that is returned by the [`S3#getObject()`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property) method in the AWS SDK, and should return the transformed object.  When a transformer function is provided, objects are not automatically converted to strings, and the `encoding` parameter is ignored.
+
 ```javascript
 const zlib = require('zlib')
 
 const transformer = object => {
-  return zlib.gunzipSync(object).toString('utf8')
+  return zlib.gunzipSync(object.Body).toString('utf8')
 }
 
 lambda
@@ -243,6 +245,7 @@ lambda
   .then(object => { /* do something with object */ })
   .catch(console.error)
 ```
+
 ### put
 put(bucket, key, object[, encoding])  
 

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -143,8 +143,7 @@ class Request {
    */
 
   forEach(func, isasync) {
-    this.concurrency(1)
-    return this.each(func, isasync)
+    return this.each(func, isasync, 1)
   }
 
   /**
@@ -155,10 +154,10 @@ class Request {
    * Promise).
    */
 
-  each(func, isAsync) {
+  each(func, isAsync, concurrency) {
 
     isAsync = isAsync || this.opts.async
-    const batch = new Batch().concurrency(this.opts.concurrency)
+    const batch = new Batch().concurrency(concurrency || this.opts.concurrency)
 
     return new Promise((success, fail) => {
       this.resolveSources().then((sources) => {

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -176,8 +176,8 @@ class Request {
 
             const bucket = source.bucket
             const key = source.key
-            const encoding = this.encoding
-            const transformer = this.transformer
+            const encoding = this.opts.encoding
+            const transformer = this.opts.transformer
 
             this.s3.get(bucket, key, encoding, transformer).then((body) => {
               if (isAsync) {
@@ -228,7 +228,7 @@ class Request {
         throw new Error('mapper function must return a value')
       }
       if (this.target == null) {
-        this.s3.put(bucket, key, body, this.encoding).then(() => {
+        this.s3.put(bucket, key, body, this.opts.encoding).then(() => {
           done()
         }).catch(done)
       } else {
@@ -236,7 +236,7 @@ class Request {
         const outputBucket = this.target.bucket
         const outputKey = key.replace(prefix, this.target.prefix)
 
-        this.s3.put(outputBucket, outputKey, body).then(() => {
+        this.s3.put(outputBucket, outputKey, body, this.opts.encoding).then(() => {
           done()
         }).catch((e) => {
           done(e)
@@ -261,8 +261,10 @@ class Request {
 
             const bucket = source.bucket
             const key = source.key
+            const encoding = this.opts.encoding
+            const transformer = this.opts.transformer
 
-            this.s3.get(bucket, key, this.encoding, this.transformer).then((val) => {
+            this.s3.get(bucket, key, encoding, transformer).then((val) => {
               if (isAsync) {
                 func(val, source.key).then((newval) => {
                   mapOutput(bucket, key, source.prefix, newval, done)
@@ -322,19 +324,19 @@ class Request {
         sources.forEach((source) => {
           batch.push((done) => {
 
-            const b = source.bucket
-            const k = source.key
-            const e = this.encoding
-            const t = this.transformer
+            const bucket = source.bucket
+            const key = source.key
+            const encoding = this.opts.encoding
+            const transformer = this.opts.transformer
 
-            this.s3.get(b, k, e, t).then((body) => {
+            this.s3.get(bucket, key, encoding, transformer).then((body) => {
               if (isAsync) {
-                func(val, body, k).then((newval) => {
+                func(val, body, key).then((newval) => {
                   val = newval
                   done()
                 }).catch(done)
               } else {
-                val = func(val, body, k)
+                val = func(val, body, key)
                 done()
               }
             }).catch(done)
@@ -421,8 +423,10 @@ class Request {
 
             const bucket = source.bucket
             const key = source.key
+            const encoding = this.opts.encoding
+            const transformer = this.opts.transformer
 
-            this.s3.get(bucket, key, this.encoding, this.transformer).then((body) => {
+            this.s3.get(bucket, key, encoding, transformer).then((body) => {
               if (isAsync) {
                 func(body, source).then((result) => {
                   check(result)

--- a/lib/S3.js
+++ b/lib/S3.js
@@ -67,12 +67,12 @@ class S3 {
    * @returns {Promise} The s3 text object.
    */
 
-  get(bucket, key, transformer) {
+  get(bucket, key, encoding, transformer) {
 
     // Default transform is to assume a text file, and call toString()
     // with the set encoding
     if (typeof transformer === 'undefined') {
-      transformer = obj => obj.Body.toString(this.encoding)
+      transformer = obj => obj.Body.toString(encoding || this.encoding)
     }
 
     return new Promise((success, fail) => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "progress": "^1.1.8"
   },
   "devDependencies": {
-    "array-equal": "^1.0.0",
     "eslint": "^3.13.1",
     "eslint-config-airbnb": "^14.0.0",
     "eslint-config-airbnb-base": "^11.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -203,6 +203,36 @@ test('S3Lambda.context.forEach (async)', (t) => {
       success()
     }), true).then(() => {
       t.ok(arraysEqual(objects, answer), 'forEach async')
+
+test('S3Lambda.context.transform and S3Lambda.context.forEach (async)', (t) => {
+
+  resetSandbox()
+  t.plan(1)
+
+  const objects = []
+  const answer = [
+    { object: 'FILE1', key: 'files/file1' },
+    { object: 'FILE2', key: 'files/file2' },
+    { object: 'FILE3', key: 'files/file3' },
+    { object: 'FILE4', key: 'files/file4' }
+  ]
+
+  const context = {
+    bucket: bucket,
+    prefix: prefix
+  }
+
+  lambda
+    .context(context)
+    .transform(obj => obj.Body.toString('utf8').toUpperCase())
+    .forEach((obj, key) => new Promise((success, fail) => {
+      objects.push({
+        object: obj,
+        key
+      })
+      success()
+    }), true).then(() => {
+      t.deepEqual(objects, answer, 'forEach async')
     })
 })
 


### PR DESCRIPTION
Ensures that transformation functions and encoding settings are actually passed through to the underlying S3 service calls.  Previously, `context.transform()` and `context.encoding()` had absolutely no effect.

Adds some documentation to give slightly more detail about how transformation functions should be used, and correctly notes the structure of the objects that are passed into transformation functions.

Slightly restructures tests to use tape's built-in assertions.  (While writing my tests, I discovered that the existing array-equality assertions didn't actually do anything)

Also fixes an unrelated bug where calling `forEach()` would reset (and persist) the context's `concurrency` to `1`, and adds tests to ensure that `forEach` does not exhibit any parallelism.

Fixes #47 