### PR TITLE
Add exclude modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ After setting context, you can chain several other functions that modify the ope
 ### .concurrency(c)
 {Number} Set the request concurrency level (default is `Infinity`).
 
+### .exclude(e)
+{Function} Sets the exclude function to use before getting objects from S3. This function will be called with the key and should return `true` if the object should be excluded.  
+**Example:** exclude png files
+```javascript
+lambda
+  .context(context)
+  .exclude(key => /.png$/.test(key))
+  .each(...)
+```
+
 ### .transform(f)
 {Function} Sets the transformation function to use when getting objects. This transformer will be called with the raw object that is returned by the [`S3#getObject()`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property) method in the AWS SDK, and should return the transformed object.  When a transformer function is provided, objects are not automatically converted to strings, and the `encoding` parameter is ignored.  
 **Example:** unzipping compressed S3 files before each operation

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -42,6 +42,7 @@ class Request {
       this.getObjects.then((objects) => {
         objects = this.opts.reverse ? objects.reverse() : objects
         objects = this.opts.limit ? objects.slice(0, this.opts.limit) : objects
+        objects = this.opts.exclude ? objects.filter(obj => !this.opts.exclude(obj.key)) : objects
         success(objects)
       }).catch(fail)
     })
@@ -62,6 +63,20 @@ class Request {
       })
       batch.on('progress', () => progress.tick())
     }
+  }
+
+  /**
+   * Sets an exclude function to be used before getting objects from s3.
+   *
+   * @param {Function} e The function to use to exclude objects. The exclude
+   * functions takes an s3 key as a parameter and should return true if the
+   * object should be excluded.
+   * @return {Request} The instance on which this method was called.
+   */
+
+  exclude(e) {
+    this.opts.exclude = e
+    return this
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -208,6 +208,37 @@ test('S3Lambda.context.forEach (async)', (t) => {
   })
 })
 
+test('S3Lambda.context.exclude and S3Lambda.context.forEach (async)', (t) => {
+
+  resetSandbox()
+  t.plan(1)
+
+  const objects = []
+  const answer = [
+    { object: 'file1', key: 'files/file1' },
+    { object: 'file3', key: 'files/file3' },
+    { object: 'file4', key: 'files/file4' }
+  ]
+
+  const context = {
+    bucket: bucket,
+    prefix: prefix
+  }
+
+  lambda
+    .context(context)
+    .exclude(key => /file2/.test(key))
+    .forEach((obj, key) => new Promise((success, fail) => {
+      objects.push({
+        object: obj,
+        key
+      })
+      success()
+    }), true).then(() => {
+      t.deepEqual(objects, answer, 'forEach async with exclude')
+    })
+})
+
 test('S3Lambda.context.transform and S3Lambda.context.forEach (async)', (t) => {
 
   resetSandbox()
@@ -236,7 +267,7 @@ test('S3Lambda.context.transform and S3Lambda.context.forEach (async)', (t) => {
       })
       success()
     }), true).then(() => {
-      t.deepEqual(objects, answer, 'forEach async')
+      t.deepEqual(objects, answer, 'forEach async with transform')
     })
 })
 


### PR DESCRIPTION
This allows to exclude keys before lambda functions operations avoiding unnecessary S3 GET operations.

* Add exclude modifier in Request
* Update README
* Add test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/littlstar/s3-lambda/58)
<!-- Reviewable:end -->
