### PR TITLE
ignore empty objects (including folder prefixes) when listing keys

### DIFF
--- a/lib/S3.js
+++ b/lib/S3.js
@@ -280,7 +280,13 @@ class S3 {
         } else {
 
           // Update key values, removing the prefix
-          let keyValues = keys.Contents.map(key => key.Key)
+          let keyValues = keys.Contents
+            .filter(object => {
+              const empty = object.Size === 0
+              const isDir = object.Key.lastIndexOf('/') === object.Key.length - 1
+              return !(empty && isDir)
+            })
+            .map(key => key.Key)
 
           // If the stop prefix is reached, ignore the rest of the keys
           let stopPrefixReached = false


### PR DESCRIPTION
before, empty objects were added to the keys. this messes up 