### PR TITLE
Add Support for signatureVersion v4. Can be set in Config Object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ lambda.context({
   prefix: 'prefix/',         // The prefix of the files to use - s3-lambda will operate over every file with this prefix.
   marker: 'prefix/file1',    // Optional. Start at the first file with this prefix. If it is a full file path, starts with next file. Defaults to null.
   endPrefix: 'prefix/file3', // Optional. Process files up to (not including) this prefix. Defaults to null.
+  match: /2017/i, // Optional. Process files matching this regex / string. Defaults to null.
   limit: 1000,               // Optional. Limit the # of files operated over. Default is Infinity.
   reverse: false             // Optional. If true, operate over all files in reverse. Defaults to false.
 })
@@ -142,7 +143,7 @@ map(fn[, isasync])
 Maps `fn` over each file in an S3 directory, replacing each file with what is returned
 from the mapper function.   If `isasync` is true, `fn` should return a Promise.
 
-This is a **destructive** action, meaning what you return from `fn` will change the S3 object itself. For your protection, you must specify `inplace()` to map over the existing files. Alternatively, you can use `output()` to output the results of the mapper function elsewhere (as demonstrated below). You can pass a third argument (a function) to rename the output key (bucket + prefix). 
+This is a **destructive** action, meaning what you return from `fn` will change the S3 object itself. For your protection, you must specify `inplace()` to map over the existing files. Alternatively, you can use `output()` to output the results of the mapper function elsewhere (as demonstrated below). You can pass a third argument (a function) to rename the output key (bucket + prefix).
 ```javascript
 const addSmiley = object => object + ':)'
 
@@ -186,7 +187,7 @@ filter(func[, isasync])
 
 **Destructive**.  Filters (deletes) files in S3. `func` should return `true` to keep the object, and `false` to delete it. If `isasync` is true, `func` returns a Promise.
 
-This is a **destructive** action, meaning if `fn` is `false`, the object will be deleted from S3. For your protection, you must specify `inplace()` to filter the existing files. Alternatively, you can use `output()` to output the results of the filter function elsewhere (as demonstrated below). As with map, you can pass a function to output to rename the output key. 
+This is a **destructive** action, meaning if `fn` is `false`, the object will be deleted from S3. For your protection, you must specify `inplace()` to filter the existing files. Alternatively, you can use `output()` to output the results of the filter function elsewhere (as demonstrated below). As with map, you can pass a function to output to rename the output key.
 
 ```javascript
 // filters empty files

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const lambda = new S3Lambda({
   secretAccessKey: 'aws-secret-key',   // Optional. (falls back on local AWS credentials)
   showProgress: true,                  // Optional. Show progress bar in stdout
   verbose: true,                       // Optional. Show all S3 operations in stdout (GET, PUT, DELETE)
-  signatureVersion: 'v4',                       // Optional. Signature Version used in Authentication. Defaults to "v4"
+  signatureVersion: 'v4',              // Optional. Signature Version used in Authentication. Defaults to "v4"
   maxRetries: 10,                      // Optional. Maximum request retries on an S3 object. Defaults to 10.
   timeout: 10000                       // Optional. Amount of time for request to timeout. Defaults to 10000 (10s)
 })
@@ -47,7 +47,7 @@ lambda.context({
   prefix: 'prefix/',         // The prefix of the files to use - s3-lambda will operate over every file with this prefix.
   marker: 'prefix/file1',    // Optional. Start at the first file with this prefix. If it is a full file path, starts with next file. Defaults to null.
   endPrefix: 'prefix/file3', // Optional. Process files up to (not including) this prefix. Defaults to null.
-  match: /2017/i, // Optional. Process files matching this regex / string. Defaults to null.
+  match: /2017/i,            // Optional. Process files matching this regex / string. Defaults to null.
   limit: 1000,               // Optional. Limit the # of files operated over. Default is Infinity.
   reverse: false             // Optional. If true, operate over all files in reverse. Defaults to false.
 })

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ const lambda = new S3Lambda({
   secretAccessKey: 'aws-secret-key',   // Optional. (falls back on local AWS credentials)
   showProgress: true,                  // Optional. Show progress bar in stdout
   verbose: true,                       // Optional. Show all S3 operations in stdout (GET, PUT, DELETE)
+  signatureVersion: 'v4',                       // Optional. Signature Version used in Authentication. Defaults to "v4"
   maxRetries: 10,                      // Optional. Maximum request retries on an S3 object. Defaults to 10.
   timeout: 10000                       // Optional. Amount of time for request to timeout. Defaults to 10000 (10s)
 })

--- a/lib/S3.js
+++ b/lib/S3.js
@@ -48,6 +48,7 @@ class S3 {
       // Create AWS S3 object
       this.s3Instance = new aws.S3({
         maxRetries: config.maxRetries || 10,
+        signatureVersion: config.signatureVersion || 'v4',
         httpOptions: {
           timeout: config.timeout || 10000
         },

--- a/lib/S3Lambda.js
+++ b/lib/S3Lambda.js
@@ -69,6 +69,7 @@ class S3Lambda extends S3 {
    * @param {Object} context An object representing an S3 context
    * @param {String} context.bucket The S3 bucket
    * @param {String} context.prefix The prefix key to use to find objects
+   * @param {String} context.match A string or regex for the key to match
    * @param {String} [context.endPrefix] Optional. The prefix to stop at (alphabetically)
    * @param {String} [context.marker] Optional. The marker to use to start listing keys at
    */
@@ -84,6 +85,7 @@ class S3Lambda extends S3 {
           const bucket = context.bucket
           const prefix = context.prefix
           const endPrefix = context.endPrefix
+          const match = context.match
           const marker = context.marker
           const reverse = context.reverse
           const limit = context.limit
@@ -96,6 +98,9 @@ class S3Lambda extends S3 {
               prefix: context.prefix,
               key
             }))
+            if (match) {
+              sources = sources.filter((line)=>line.key.match(match))
+            }
             if (reverse) {
               sources = sources.reverse()
             }

--- a/lib/S3Lambda.js
+++ b/lib/S3Lambda.js
@@ -99,7 +99,7 @@ class S3Lambda extends S3 {
               key
             }))
             if (match) {
-              sources = sources.filter((line)=>line.key.match(match))
+              sources = sources.filter(object => object.key.match(match))
             }
             if (reverse) {
               sources = sources.reverse()


### PR DESCRIPTION
Hi,

I had aproblem access my bucket because AWS wouldn't allow me to access my bucket with a signature version different from v4.
I just added the possibility to set signature version in config, with default set at v4.
